### PR TITLE
QA-QC Updates: Round 1

### DIFF
--- a/xradial/dataframe.py
+++ b/xradial/dataframe.py
@@ -171,6 +171,11 @@ def reindex_df_by_range_bearing(df, angular_res,
     unique_bearing_diffs = np.diff(np.unique(df['BEAR']))
 
     df = df.set_index([time_var_str, 'BEAR', 'RNGE'])
+
+    # if the DataFrame has only 1 row, there will be no bearing diffs; in
+    # this case, simply set the multi index and return the dataframe    
+    if unique_bearing_diffs.shape[0] < 1:
+        return df
     
     # deal with missing angular resolution metadata
     if not angular_res:

--- a/xradial/utils.py
+++ b/xradial/utils.py
@@ -93,6 +93,21 @@ def get_range_res_start_end(metadata):
     range_end = metadata.get('RangeEnd', None)
     range_resolution_kmeters = metadata.get('RangeResolutionKMeters', None)
     range_resolution_meters = metadata.get('RangeResolutionMeters', None)
+
+    # assert numeric types
+    if not any(
+        [
+            isinstance(range_resolution_kmeters, float),
+            isinstance(range_resolution_kmeters, int),
+            isinstance(range_resolution_meters, float),
+            isinstance(range_resolution_meters, int)
+        ]):
+        raise ValueError("Range resolutions must be numeric")
+
+    # if km doesn't exist, create it from meters
+    if (not range_resolution_kmeters) and (range_resolution_meters):
+        range_resolution_kmeters = range_resolution_meters / 1000.
+
     return (range_start, range_end, range_resolution_kmeters, range_resolution_meters)
 
 def get_range_resolution_precision(range_resolution_kmeters, range_resolution_meters):


### PR DESCRIPTION
Implement fixes for several errors encountered:

1) "unsupported operand type(s) for '/': 'float' and 'NoneType'":
   Create range_resolution_km from range_resolution_meters if KM does not exist

2) "zero-size array to reduction opertation minimum which has no identity":
   When the DataFRame has length of one, return early with multi-index instead
   of trying to create multi-index from differential values